### PR TITLE
fix sidebar projects link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ logoalt: CFPB
 # List links that should appear in the site sidebar here
 navigation:
 - text: Projects
-  url: ./
+  url: ./projects
   internal: true
 - text: Workshops
   url: ./workshops


### PR DESCRIPTION
projects link should go to projects page now, not index page (whoops)
